### PR TITLE
Remove gcID from query - it is no longer a required parameter

### DIFF
--- a/packages/global-nav/components/NotificationDropdown.js
+++ b/packages/global-nav/components/NotificationDropdown.js
@@ -35,8 +35,8 @@ const notificationClient = new ApolloClient({
 });
 
 const GET_NOTIFICATIONS = gql`
-query notifications($gcID: String!){
-  notifications(gcID:$gcID){
+query notifications{
+  notifications{
     id,
     actionLink,
     generatedOn,


### PR DESCRIPTION
removed the gcID parameter from the call to notification as a service.  The token is now used to find the gcID of the user on the backend.  This ensure that a valid token can't query other users notifications.