### PR TITLE
Update package.json to pull in an updated virtualenv lib

### DIFF
--- a/packages/i18n-translation-webpack-plugin/package.json
+++ b/packages/i18n-translation-webpack-plugin/package.json
@@ -26,7 +26,7 @@
     "md5-file": "~3.2.3",
     "object-assign": "^4.1.1",
     "po-loader": "~0.4.1",
-    "virtualenv": "git+https://github.com/lucbelliveau/node-virtualenv.git",
+    "virtualenv": "git+https://github.com/phanoix/node-virtualenv.git",
     "webpack": "^4.16.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow use of the legacy version of virtualenv that the package can work with.

fixes gctools-outilsgc/directory-fe#78