### PR TITLE
Updated i18n-translation-webpack-plugin for two packages

### DIFF
--- a/packages/language-selector/package.json
+++ b/packages/language-selector/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@gctools-components/eslint-config": "^1.1.3",
-    "@gctools-components/i18n-translation-webpack-plugin": "^1.1.5",
+    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.2",
     "@gctools-components/jest-config": "^1.1.3",
     "@storybook/addon-actions": "^3.4.0",
     "@storybook/addon-info": "^3.4.0",

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -6,7 +6,7 @@
     "@gctools-components/autocomplete-graphql": "^0.0.4",
     "@gctools-components/gc-login": "^1.1.3",
     "@gctools-components/gcconnex-ref-impl": "^0.0.5",
-    "@gctools-components/i18n-translation-webpack-plugin": "^1.1.5",
+    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.2",
     "@gctools-components/language-selector": "^1.1.5",
     "@gctools-components/phrase-cloud": "^1.1.3",
     "@gctools-components/phrase-cloud-treemap": "^1.1.3",


### PR DESCRIPTION
Fixes error when running `lerna bootstrap`. Development environment should now run properly.