### PR TITLE
I18n package update

### DIFF
--- a/packages/i18n-translation-webpack-plugin/package.json
+++ b/packages/i18n-translation-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gctools-components/i18n-translation-webpack-plugin",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Complete i18n translation solution for webpack, including code-splitting and automatic generation of translation files",
   "main": "dist/plugin.js",
   "repository": {
@@ -27,7 +27,7 @@
     "md5-file": "~3.2.3",
     "object-assign": "^4.1.1",
     "po-loader": "~0.4.1",
-    "virtualenv": "git+https://github.com/phanoix/node-virtualenv.git",
+    "virtualenv": "git+https://github.com/gctools-outilsgc/node-virtualenv",
     "webpack": "^4.16.1",
     "snyk": "^1.370.0"
   },

--- a/packages/i18n-translation-webpack-plugin/package.json
+++ b/packages/i18n-translation-webpack-plugin/package.json
@@ -27,7 +27,7 @@
     "md5-file": "~3.2.3",
     "object-assign": "^4.1.1",
     "po-loader": "~0.4.1",
-    "virtualenv": "git+https://github.com/gctools-outilsgc/node-virtualenv",
+    "virtualenv": "git+https://github.com/gctools-outilsgc/node-virtualenv.git",
     "webpack": "^4.16.1",
     "snyk": "^1.370.0"
   },

--- a/packages/language-selector/package.json
+++ b/packages/language-selector/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@gctools-components/eslint-config": "^1.1.3",
-    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.2",
+    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.3",
     "@gctools-components/jest-config": "^1.1.3",
     "@storybook/addon-actions": "^3.4.0",
     "@storybook/addon-info": "^3.4.0",

--- a/packages/reference-implementation/package.json
+++ b/packages/reference-implementation/package.json
@@ -6,7 +6,7 @@
     "@gctools-components/autocomplete-graphql": "^0.0.4",
     "@gctools-components/gc-login": "^1.1.3",
     "@gctools-components/gcconnex-ref-impl": "^0.0.5",
-    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.2",
+    "@gctools-components/i18n-translation-webpack-plugin": "^2.0.3",
     "@gctools-components/language-selector": "^1.1.5",
     "@gctools-components/phrase-cloud": "^1.1.3",
     "@gctools-components/phrase-cloud-treemap": "^1.1.3",


### PR DESCRIPTION
Switch i18n-translation-webpack-plugin to use node-virtualenv repo from our org and with updated fix. Also updated npm version and packages that have dependencies on i18n-translation-webpack-plugin.